### PR TITLE
User password via console

### DIFF
--- a/src/main/java/org/wmaop/bdd/steps/ExecutionContext.java
+++ b/src/main/java/org/wmaop/bdd/steps/ExecutionContext.java
@@ -11,6 +11,7 @@ import com.wm.data.IDataFactory;
 
 public class ExecutionContext {
 
+	private static final Logger logger = Logger.getLogger(ExecutionContext.class);
 	private Context context;
 	private IData pipeline;
 	private Throwable thrownException;
@@ -31,7 +32,19 @@ public class ExecutionContext {
 		String host = p.getProperty("wm.server.host", "localhost");
 		int port = Integer.parseInt(p.getProperty("wm.server.port", "5555"));
 		String username = p.getProperty("wm.server.username", "Administrator");
-		String password = p.getProperty("wm.server.password", "manage");
+		String password = p.getProperty("wm.server.password", null); // set to null if not defined
+		if(password == null){
+			// if we don't have a defined password, prompt for one from user
+			Console console = System.console();
+			try{
+				password = new String(console.readPassword("WebMethods Server Password: "));
+			} catch(IOException e){
+				// if we had an error reading in user's password, use wm default pw
+				logger.warn("Could not read password: " + e.toString() );
+				logger.warn("Attempting to proceed with webMethods default password.");
+				password = "manage";
+			}
+		}
 		boolean secure = Boolean.parseBoolean(p.getProperty("wm.server.secure", "false"));
 		return connectToServer(host, port, username, password, secure);
 	}


### PR DESCRIPTION
This change should check for a password configured via the vm arguments as is currently the case. If one is not found, it will prompt the user for a password via the console (requiring java 1.6 or above). If there is an IOException thrown from that operation, then it uses the log4j logger to warn about the exception and that it will attempt to proceed with the wm default password.

I say "should" because this is untested. I am unable to build the project on my machine due to unavailable dependencies declared in the pom.xml file. Please be thorough in testing this as I am unable to.

This pull request should address the enhancement described in Issue #2 .


It strikes me that this approach may actually be useful to extend to all the server attributes (host, port, user, and secure connection). If they are not defined, the console could output a message prompting for each value, as well as a quick message describing how to add the various values to the vm arguments. This would improve the usability of the tool by removing the need for prior knowledge on how to configure these parameters.

As this would require more extensive changes, I've kept this to just the password for the moment. If you like this idea, I can add the other changes to this pull request before you accept.