### PR TITLE
Jasypt Encryptable Properties File

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,11 @@
 			<artifactId>javax.mail-api</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.jasypt</groupId>
+			<artifactId>jasypt</artifactId>
+			<version>1.9.2</version>
+		</dependency>
+		<dependency>
 			<groupId>com.entrust</groupId>
 			<artifactId>toolkit</artifactId>
 		</dependency>

--- a/src/main/java/org/wmaop/bdd/steps/ExecutionContext.java
+++ b/src/main/java/org/wmaop/bdd/steps/ExecutionContext.java
@@ -16,7 +16,7 @@ import com.wm.data.IData;
 import com.wm.data.IDataFactory;
 
 public class ExecutionContext {
-
+	
 	private static final Logger logger = Logger.getLogger(ExecutionContext.class);
 	private Context context;
 	private IData pipeline;
@@ -35,10 +35,11 @@ public class ExecutionContext {
 	
 	private Context createConnectionContext() throws ServiceException {
 		Properties system = System.getProperties();
+		String symmetricPassword = system.getProperty("symmetricPassword", "wm-jbehave-jasypt");
 		
 		// Create Jasypt wrapped properties object
 		StandardPBEStringEncryptor encryptor = new StandardPBEStringEncryptor();
-		encryptor.setPassword("wm-jbehave-jasypt");
+		encryptor.setPassword(symmetricPassword);
 		Properties p = new EncryptableProperties(system, encryptor);
 		
 		// Attempt to load config.properties file

--- a/src/main/java/org/wmaop/bdd/steps/ExecutionContext.java
+++ b/src/main/java/org/wmaop/bdd/steps/ExecutionContext.java
@@ -45,7 +45,7 @@ public class ExecutionContext {
 			try {
 				ctx.connect(host, port, username, password);
 			} catch (Exception e) {
-				Assert.fail("Unable to connect to " + host+':'+port+ " with "+username+'/'+password + " - " + e.getMessage());
+				Assert.fail("Unable to connect to " + host+':'+port+ " with user " + username + " - " + e.getMessage());
 			}
 		}
 		return ctx;


### PR DESCRIPTION
This pull request implements feature described in Issue #2 regarding providing a secure method to store passwords.

As previously discussed in emails, this approach uses the Jasypt library to wrap the Properties object, allowing for encryptable fields to be provided.

Documentation will need to be updated to describe how to use the Jasypt CLI tools to create encrypted values.

This implementation expects the properties file to be named "config.properties". It is loaded using the ClassLoader so it can be located anywhere in the classpath.

The symmetric encryption password is retrieved from the System.getProperties() object, and will default to "wm-jbehave-jasypt".

The implementation also continues to use the System Properties object as the default Properties base, so if config.properties is not defined, and fields are configured via VM arguments as in past versions, they will continue to work.

Lastly, this pull request also modifies the error output when a connection fails to be made. The password will no longer be shown as part of the error message. Instead, just the server, port, username and a message saying "Invalid credentials" will be shown.