### PR TITLE
Bug fix for comparing documents with different system line endings

### DIFF
--- a/src/main/java/org/wmaop/bdd/steps/DocumentMatchStep.java
+++ b/src/main/java/org/wmaop/bdd/steps/DocumentMatchStep.java
@@ -96,6 +96,32 @@ public class DocumentMatchStep extends BaseServiceStep {
 		} else {
 			docVal = docObj;
 		}
+		// Bug fix: Accomodate if strings have different line breaks (\n\r and \n)
+		if(docVal instanceof String[][] && potObj instanceof String[][]){
+			for(String[] a: (String[][]) potObj){
+				for(String b: a){
+					b = b.replaceAll("\r", "");
+				}
+			}
+			for(String[] a: (String[][]) docVal){
+				for(String b: a){
+					b = b.replaceAll("\r", "");
+				}
+			}
+		}
+		else if(docVal instanceof String[] && potObj instanceof String[]){
+			for(String a: (String[]) potObj){
+				a = a.replaceAll("\r", "");
+			}
+			for(String a: (String[]) docVal){
+				a = a.replaceAll("\r","");
+			}
+		}
+		else if(docVal instanceof String && potObj instanceof String){
+			potObj = (Object) ((String) potObj).replaceAll("\r", "");
+			docVal = (Object) ((String) docVal).replaceAll("\r", "");
+		}
+		//End bug fix
 		if (!docVal.equals(potObj)) {
 			if (reportFail) {
 				fail("Element " + prefix + '.' + key + " has pipeline value of '" + docObj + "' but test value of '"


### PR DESCRIPTION
This pull request includes a commit to fix comparing documents after a test that may have differing line endings but are otherwise equivalent.