### PR TITLE
PR With 2 New Features and 1 Bugfix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>wm-jbehave</artifactId>
-	<version>1.1.6-SNAPSHOT</version>
+	<version>1.1.6</version>
 	<packaging>jar</packaging>
 
 	<parent>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>wm-jbehave</artifactId>
-	<version>1.1.5</version>
+	<version>1.1.6-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<parent>

--- a/src/main/java/org/wmaop/bdd/jbehave/WmJBehaveSteps.java
+++ b/src/main/java/org/wmaop/bdd/jbehave/WmJBehaveSteps.java
@@ -135,6 +135,18 @@ public class WmJBehaveSteps  {
 		 * Utility 
 		 */
 
+		@Given("capture pipeline $interceptPoint service $serviceName into $fileName always")
+		public void capture_pipeline(String interceptPoint, String serviceName, String pipelineFileName){
+			BddTestBuilder bddt = ThreadContext.get();
+			bddt.capturePipeline(serviceName+ "-" + bddt.getExecutedStep(), interceptPoint, serviceName, pipelineFileName, null);
+		}
+		
+		@Given("capture pipeline $interceptPoint service $serviceName into $fileName when $condition")
+		public void capture_pipeline_with_condition(String interceptPoint, String serviceName, String pipelineFileName, String condition){
+			BddTestBuilder bddt = ThreadContext.get();
+			bddt.capturePipeline(serviceName+ "-" + bddt.getExecutedStep(), interceptPoint, serviceName, pipelineFileName, condition);
+		}
+		
 		@Then("show pipeline in console")
 		public void showPipeline() {
 			ThreadContext.get().showPipeline();

--- a/src/main/java/org/wmaop/bdd/jbehave/WmJBehaveSteps.java
+++ b/src/main/java/org/wmaop/bdd/jbehave/WmJBehaveSteps.java
@@ -12,6 +12,7 @@ import org.jbehave.core.annotations.When;
 import org.wmaop.bdd.steps.BddTestBuilder;
 import org.wmaop.bdd.steps.InterceptPoint;
 import org.wmaop.bdd.steps.ThreadContext;
+import org.wmaop.bdd.utils.BraceExpansionTool;
 
 public class WmJBehaveSteps  {
 
@@ -46,16 +47,18 @@ public class WmJBehaveSteps  {
 			ThreadContext.get().withVariableExpression(jexlVariableExpression);
 		}
 
-		@Given("mock $serviceName always returning $idataFiles")
-		public void mock_service_always_returning(String serviceName, List<String> idataFiles) {
-			ThreadContext.get().withMockService(serviceName, InterceptPoint.invoke, serviceName, idataFiles, null, null);
+		@Given("mock $serviceName always returning $idataFilesString")
+		public void mock_service_always_returning(String serviceName, String idataFilesString) {
+			List<String> idataFilesList = BraceExpansionTool.expand(idataFilesString);
+			ThreadContext.get().withMockService(serviceName, InterceptPoint.invoke, serviceName, idataFilesList, null, null);
 		}
 		
 		
-		@Given("mock $serviceName returning $idataFiles when $jexlPipelineExpression")
-		public void mock_service_returning_when(String serviceName, List<String> idataFiles, String jexlPipelineExpression) throws Throwable {
+		@Given("mock $serviceName returning $idataFilesString when $jexlPipelineExpression")
+		public void mock_service_returning_when(String serviceName, String idataFilesString, String jexlPipelineExpression) throws Throwable {
+			List<String> idataFilesList = BraceExpansionTool.expand(idataFilesString);
 			BddTestBuilder bddt = ThreadContext.get();
-			bddt.withMockService(serviceName + "-" + bddt.getExecutedStep(), InterceptPoint.invoke, serviceName, idataFiles, jexlPipelineExpression, null);
+			bddt.withMockService(serviceName + "-" + bddt.getExecutedStep(), InterceptPoint.invoke, serviceName, idataFilesList, jexlPipelineExpression, null);
 		}
 
 		

--- a/src/main/java/org/wmaop/bdd/steps/BaseServiceStep.java
+++ b/src/main/java/org/wmaop/bdd/steps/BaseServiceStep.java
@@ -34,6 +34,7 @@ public abstract class BaseServiceStep {
 	protected static final String SETUP_ASSERTION = "org.wmaop.define.assertion:registerAssertion";
 	protected static final String ASSERTION_INVOKE_COUNT = "org.wmaop.define.assertion:getInvokeCount";
 	protected static final String REGISTER_EXCEPTION = "org.wmaop.define.exception:registerExceptionMock";
+	protected static final String REGISTER_SCENARIO = "org.wmaop.define.scenario:registerScenario";
 	
 	protected class ServiceSplit {
 		protected String packageName;

--- a/src/main/java/org/wmaop/bdd/steps/BddTestBuilder.java
+++ b/src/main/java/org/wmaop/bdd/steps/BddTestBuilder.java
@@ -77,6 +77,11 @@ public class BddTestBuilder {
 		MockServiceStep step = new MockServiceStep(adviceId, invoke, serviceName, idataFile, jexlPipelineExpression, pkgService);
 		executeStep(step);
 	}
+	
+	public void capturePipeline(String adviceId, String interceptPoint, String serviceName, String pipelineFileName, String condition){
+		CapturePipelineStep step = new CapturePipelineStep(adviceId, interceptPoint, serviceName, pipelineFileName, condition);
+		executeStep(step);
+	}
 
 	public void withPipelineExpression(String jexlExpression) {
 		PipelineJexlStep step = new PipelineJexlStep(jexlExpression);

--- a/src/main/java/org/wmaop/bdd/steps/CapturePipelineStep.java
+++ b/src/main/java/org/wmaop/bdd/steps/CapturePipelineStep.java
@@ -1,0 +1,46 @@
+package org.wmaop.bdd.steps;
+
+import com.wm.data.IData;
+import com.wm.data.IDataCursor;
+import com.wm.data.IDataFactory;
+import com.wm.data.IDataUtil;
+
+public class CapturePipelineStep extends BaseServiceStep {
+
+	private final IData idata = IDataFactory.create();
+
+	public CapturePipelineStep(String adviceId, String interceptPoint, String serviceName, String pipelineFileName,
+			String condition){
+		setup(adviceId, toInteceptPoint(interceptPoint), serviceName, pipelineFileName, condition);
+	}
+	
+	public void setup(String adviceId, InterceptPoint interceptPoint, String serviceName, String pipelineFileName,
+			String condition) {
+		IDataCursor cursor = idata.getCursor();
+		
+		String scenarioAsString = 
+			"<?xml version=\"1.0\"?>"
+			+ "<scenario id=\"" + adviceId + "\">"
+				+ "<scope>"
+					+ "<session/>"
+				+ "</scope>"
+				+ "<given>"
+					+ "<service intercepted=\"" + interceptPoint.toString() + "\">" + serviceName + "</service>"
+				+ "</given>"
+				+ (condition == null ? "<when>" : "<when condition=\'" + condition + "\'>")
+					+ "<then>"
+						+ "<pipelineCapture>" + pipelineFileName + "</pipelineCapture>"
+					+ "</then>"
+				+ "</when>"
+			+ "</scenario>";
+		System.out.println(scenarioAsString);
+		IDataUtil.put(cursor, "scenarioAsString", scenarioAsString);
+		cursor.destroy();
+		
+	}
+	
+	@Override
+	protected void execute(ExecutionContext executionContext) throws Exception {
+		invokeService(executionContext, REGISTER_SCENARIO, idata);
+	}
+}

--- a/src/main/java/org/wmaop/bdd/steps/DocumentMatchStep.java
+++ b/src/main/java/org/wmaop/bdd/steps/DocumentMatchStep.java
@@ -4,6 +4,8 @@ import org.wmaop.util.jexl.ExpressionProcessor;
 import org.wmaop.util.jexl.IDataJexlContext;
 import static org.junit.Assert.*;
 
+import java.util.Arrays;
+
 import com.wm.data.IData;
 import com.wm.data.IDataCursor;
 import com.wm.data.IDataFactory;
@@ -122,12 +124,32 @@ public class DocumentMatchStep extends BaseServiceStep {
 			docVal = (Object) ((String) docVal).replaceAll("\r", "");
 		}
 		//End bug fix
-		if (!docVal.equals(potObj)) {
-			if (reportFail) {
-				fail("Element " + prefix + '.' + key + " has pipeline value of '" + docObj + "' but test value of '"
-						+ potObj + "'");
+		//Another bug fix: arrays will only be .equals() if they are the same object
+		//Instead, use Arrays.equals to evaluate equality of contents of two arrays 
+		if ((docVal instanceof String[][] && potObj instanceof String[][])){
+			if (!Arrays.equals((String[][])docVal,(String[][])potObj)) {
+				if (reportFail) {
+					fail("Element " + prefix + '.' + key + " has pipeline value with different array values than test value");
+				}
+				return false;
 			}
-			return false;
+		}
+		else if ((docVal instanceof String[] && potObj instanceof String[])){
+			if (!Arrays.equals((String[])docVal,(String[])potObj)) {
+				if (reportFail) {
+					fail("Element " + prefix + '.' + key + " has pipeline value with different array values than test value");
+				}
+				return false;
+			}
+		}
+		else{
+			if (!docVal.equals(potObj)) {
+				if (reportFail) {
+					fail("Element " + prefix + '.' + key + " has pipeline value of '" + docObj + "' but test value of '"
+							+ potObj + "'");
+				}
+				return false;
+			}
 		}
 		return true;
 	}

--- a/src/main/java/org/wmaop/bdd/utils/BraceExpansionTool.java
+++ b/src/main/java/org/wmaop/bdd/utils/BraceExpansionTool.java
@@ -1,0 +1,30 @@
+package org.wmaop.bdd.utils;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class BraceExpansionTool {
+	
+	public static List<String> expand(String inputString){
+		if (inputString == null){ 
+			return null;
+		}
+		
+		List<String> newList = new ArrayList<String>();
+		
+		// Look to see if we have Curly Braces to expand
+		if(inputString.matches(".+\\{.+\\}.+")){
+			String[] splitInput = inputString.split("[\\{,\\}]");
+			for(int i=1; i<splitInput.length-1;i++){
+				newList.add(splitInput[0] + splitInput[i] + splitInput[splitInput.length-1]);
+			}
+		}
+		else{
+			newList = new ArrayList<String>(Arrays.asList(inputString.split(",")));
+		}
+		
+		return newList;
+	}
+
+}

--- a/src/main/java/org/wmaop/bdd/utils/IDataMergeTool.java
+++ b/src/main/java/org/wmaop/bdd/utils/IDataMergeTool.java
@@ -38,6 +38,8 @@ public class IDataMergeTool {
 				IDataUtil.put(ipCursor, currentKey, orCursor.getValue());
 			}				
 		}
+		orCursor.destroy();
+		ipCursor.destroy();
 	}
 	
 	public static IData[] mergeNestedTypes(IData[] overrideArray, IData[] inputPipelineArray){


### PR DESCRIPTION
New features are:

**Brace expansion**: When using the Given mock story lines (both the "always returning" and "returning $ when $" patterns), we now have the ability to do curly brace expansion, similar to bash syntax.

For example, if we have a list of files and want the mock to subsequently return each one (first call, first file, second call, second file, etc.) we used to have to specify a comma delimited list. This meant lots of path repetition. IE: data/some/path/here/file1.xml,data/some/path/here/file2.xml

Now, this can instead more concisely be written as data/some/path/here/file{1,2}.xml

**Capture pipeline**: We now have a new Given step for capturing the pipeline before/instead (invoke)/after a service invocation.

Uses the syntax: "Given capture pipeline $interceptPoint service $serviceName into $fileName always"
and: "Given capture pipeline $interceptPoint service $serviceName into $fileName when $condition"

This will save the pipeline to the ESB pipeline folder. This will automatically append a number to the filename and increment it for each subsequent call.

**Bug fix: Document matching String[] and String[][] types**:
Previously would call obj.equals(obj2) to compare, but this would not match for array types as it would just compare the memory addresses to see if they are the same object. Instead we want to use Arrays.equals(obj, obj2) to compare the contents of the arrays.